### PR TITLE
Check if TreeView has attach and detach defined

### DIFF
--- a/lib/php-class-tree.coffee
+++ b/lib/php-class-tree.coffee
@@ -28,10 +28,10 @@ class PhpClassTree
     @treeView = new TreeView matches
 
   attach: ->
-    @treeView.attach()
+    @treeView?.attach()
 
   detach: ->
-    @treeView.detach()
+    @treeView?.detach()
 
   toggle: ->
     if atom.workspace.getActiveTextEditor().getGrammar().name != 'PHP'


### PR DESCRIPTION
When opening a PHP file with no classes an exception is thrown and then the plug-in can no longer create the class map view until Atom is restarted.

This patch will just check the attach and detach property of the TreeView object is defined.